### PR TITLE
Issue #16: GitHub Action for TypeCheck

### DIFF
--- a/.github/workflows/typeCheck.yaml
+++ b/.github/workflows/typeCheck.yaml
@@ -1,0 +1,26 @@
+name: 'Type Check'
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  typeCheck:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Run Coverage
+        run: yarn typeCheck

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Functions used to map props to scss class names, handle css styles, and other utilities of aspire-components.
 
-[![Pull Request Test Coverage](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepr.yaml/badge.svg)](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepr.yaml) [![Push to Main Test Coverage](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepush.yaml/badge.svg)](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepush.yaml) [![Lint Check](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/lint.yaml/badge.svg)](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/lint.yaml)
+[![Pull Request Test Coverage](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepr.yaml/badge.svg)](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepr.yaml) [![Push to Main Test Coverage](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepush.yaml/badge.svg)](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/coveragepush.yaml) [![Lint Check](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/lint.yaml/badge.svg)](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/lint.yaml) [![Type Check](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/typeCheck.yaml/badge.svg)](https://github.com/chrstnfrrs/aspire-components-functions/actions/workflows/typeCheck.yaml)
 
 ## Install
 


### PR DESCRIPTION
### Description
There should be a GitHub action for type check.

- [x] On push and pull request to main, the GitHub action should run type check.
- [x] A coverage badge should be present in the readme.

### Changes
- [x] Closes Issue #16 